### PR TITLE
Update haskell-google-server-api

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ extra-deps:
       - tonatona-persistent-sqlite
       - tonatona-servant
   - git: https://github.com/arowM/haskell-google-server-api
-    commit: 324a1de38ee14c238d8de358b9d0f42ff6be6800
+    commit: 21b877d102c86ef631a4af89ff89b15dbf3d92e0
 
 flags: {}
 extra-package-dbs: []

--- a/tonatona-google-server-api.cabal
+++ b/tonatona-google-server-api.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b271eeb993f46d83c462d961402281951cb30745679a9bd28e60aa7e01e4dbbd
+-- hash: 56633aee31ba2263f6cfaf4ce2de00cdb202015bb912d3344ed999b6eda7de7d
 
 name:           tonatona-google-server-api
-version:        0.1.3.0
+version:        0.2.0.0
 synopsis:       tonatona plugin for google-server-api
 description:    Tonatona plugin for [google-server-api](https://hackage.haskell.org/package/google-server-api). This package provides a tonatona plugin to use Google API for server to server applications.
 category:       Database, Library, Tonatona, Web


### PR DESCRIPTION
@arowM
This PR updates haskell-google-server-api package to [0.4.0.2](https://github.com/arowM/haskell-google-server-api/commit/21b877d102c86ef631a4af89ff89b15dbf3d92e0) .